### PR TITLE
Add new post_open_hook function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ require('goto-preview').setup {
     default_mappings = false; -- Bind default mappings
     debug = false; -- Print debug information
     opacity = nil; -- 0-100 opacity level of the floating window where 100 is fully transparent.
+    post_open_hook = nil -- A function taking two arguments, a buffer and a window to be ran as a hook.
   }
 ```
+
+The `post_open_hook` function gets called right before setting the cursor position in the new floating window.
+One can use this to set custom key bindings or really anything else they want to do when a new preview window opens.
 
 ### ⌨️ Mappings
 There are no mappings by default, you can set `default_mappings = true` in the config to make use of the mappings I use or define your own.  

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -12,7 +12,8 @@ local M = {
 
         return uri, { range.start.line +1, range.start.character }
       end;
-    }
+    };
+    post_open_hook = nil -- A function taking two arguments, a buffer and a window to be ran as a hook.
   }
 }
 
@@ -46,11 +47,8 @@ local windows = {}
 
 local open_floating_win = function(target, position)
   local buffer = vim.uri_to_bufnr(target)
-
   local bufpos = { vim.fn.line(".")-1, vim.fn.col(".") } -- FOR relative='win'
-
   local zindex = vim.tbl_isempty(windows) and 1 or #windows+1
-
   local new_window = vim.api.nvim_open_win(buffer, true, {
     relative='win',
     width=M.conf.width,
@@ -81,6 +79,9 @@ local open_floating_win = function(target, position)
       au WinClosed * lua require('goto-preview').remove_curr_win()
     augroup end
   ]]
+
+  local success, result = pcall(M.conf.post_open_hook, buffer, new_window)
+  logger.debug("post_open_hook call success:", success, result)
 
   vim.api.nvim_win_set_cursor(new_window, position)
 end


### PR DESCRIPTION
This addresses users who want more control over the preview windows.

An example that addresses @serhez comment on issue #7.
```lua
post_open_hook = function(buffer, _)
  vim.api.nvim_buf_set_keymap(buffer, 'n', 'q', ':q<CR>', {noremap = true})
end
```