### PR TITLE
Adhere to new lsp handler format

### DIFF
--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -90,9 +90,13 @@ M.run_hook_function = function(buffer, new_window)
   logger.debug("post_open_hook call success:", success, result)
 end
 
-local handler = function(_, _, result)
+local handler = function(err, result, ctx, config)
   if not result then return end
 
+  print('==== err', vim.inspect(err))
+  print('==== result', vim.inspect(result))
+  print('==== ctx', vim.inspect(ctx))
+  print('==== config', vim.inspect(config))
   local data = result[1]
 
   local target = nil

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -90,13 +90,9 @@ M.run_hook_function = function(buffer, new_window)
   logger.debug("post_open_hook call success:", success, result)
 end
 
-local handler = function(err, result, ctx, config)
+local handler = function(_err, result, _ctx, _config)
   if not result then return end
 
-  print('==== err', vim.inspect(err))
-  print('==== result', vim.inspect(result))
-  print('==== ctx', vim.inspect(ctx))
-  print('==== config', vim.inspect(config))
   local data = result[1]
 
   local target = nil


### PR DESCRIPTION
The preview broke with the new LSP handler function format which was changed in this pr:
https://github.com/neovim/neovim/pull/15504

Closes #20.

This was done hopefully in a backwards compatible way so the plugin should still work even if one hasn't updated Neovim.