### PR TITLE
Add support for references previews through telescope.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ nnoremap gP <cmd>lua require('goto-preview').close_all_win()<CR>
 vim.api.nvim_set_keymap("n", "gp", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
 ```
 
-If you have [Vimpeccable](https://github.com/svermeulen/vimpeccable) installed it'll use it to create the mappings, if not, builtin `nvim_set_keymap` will be used.
-
 ### Supported languages
 Goto Preview should work with LSP responses for most languages now! If something doesn't work as expected, drop an issue and I'll be happy to check it out!
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ A small Neovim plugin for previewing native LSP's goto definition calls in float
 ### 🚀 Showcase
 <img src="https://github.com/rmagatti/readme-assets/blob/main/goto-preview-zoomed.gif" />
 
+#### 🔗 References
+https://github.com/rmagatti/readme-assets/blob/main/goto-preview-references.mp4
+
 ### ⚠️ IMPORTANT NOTE
 There is currently an open [Neovim TUI](https://github.com/neovim/neovim/issues/14735) bug that prevents the correct positioning of more than one preview window.
 One singular preview window should work fine but jumping to a subsequent preview will position it in an undesired spot.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ One singular preview window should work fine but jumping to a subsequent preview
 
 🎉 GUIs like [Goneovim](https://github.com/akiyosi/goneovim) and [Uivonim](https://github.com/smolck/uivonim) implement the correct positioning behaviour and will behave as intended.
 
+#### ⚠️ UPDATE
+The issue is fixed in Neovim v0.6.0-dev (master) and is set for the milestone `0.5.1` at the time of writing.
+https://github.com/neovim/neovim/pull/14770
+
 ### 📦 Installation
 Packer.nvim
 ```lua

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A small Neovim plugin for previewing native LSP's goto definition calls in float
 <img src="https://github.com/rmagatti/readme-assets/blob/main/goto-preview-zoomed.gif" />
 
 #### 🔗 References
-https://github.com/rmagatti/readme-assets/blob/main/goto-preview-references.mp4
+<img src="https://github.com/rmagatti/readme-assets/blob/main/goto-preview-references.gif" />
 
 ### ⚠️ IMPORTANT NOTE
 There is currently an open [Neovim TUI](https://github.com/neovim/neovim/issues/14735) bug that prevents the correct positioning of more than one preview window.

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -1,10 +1,5 @@
-local pickers = require('telescope.pickers')
-local make_entry = require('telescope.make_entry')
-local telescope_conf = require('telescope.config').values
-local finders = require('telescope.finders')
 local themes = require('telescope.themes')
-local actions = require('telescope.actions')
-local action_state = require('telescope.actions.state')
+local lib = require('goto-preview.lib')
 
 local M = {
   conf = {
@@ -24,162 +19,18 @@ local M = {
     };
     post_open_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
     references = {
-      telescope = themes.get_dropdown({hide_preview = false})
+      telescope = themes.get_dropdown({ hide_preview = false })
     }
   }
-}
-
-local logger = {
-  debug = function(...)
-    if M.conf.debug then
-      print("goto-preview:", ...)
-    end
-  end
 }
 
 M.setup = function(conf)
   if conf and not vim.tbl_isempty(conf) then
     M.conf = vim.tbl_extend('force', M.conf, conf)
+    lib.setup_lib(M.conf)
 
     if M.conf.default_mappings then M.apply_default_mappings() end
     if M.conf.resizing_mappings then M.apply_resizing_mappings() end
-  end
-end
-
-local function tablefind(tab,el)
-  for index, value in pairs(tab) do
-    if value == el then
-      return index
-    end
-  end
-end
-
-local windows = {}
-
-local open_floating_win = function(target, position)
-  local buffer = vim.uri_to_bufnr(target)
-  local bufpos = { vim.fn.line(".")-1, vim.fn.col(".") } -- FOR relative='win'
-  local zindex = vim.tbl_isempty(windows) and 1 or #windows+1
-  local new_window = vim.api.nvim_open_win(buffer, true, {
-    relative='win',
-    width=M.conf.width,
-    height=M.conf.height,
-    border={"↖", "─" ,"┐", "│", "┘", "─", "└", "│"},
-    bufpos=bufpos,
-    zindex=zindex, -- TODO: do I need to set this at all?
-    win=vim.api.nvim_get_current_win()
-  })
-
-  if M.conf.opacity then vim.api.nvim_win_set_option(new_window, "winblend", M.conf.opacity) end
-  vim.api.nvim_buf_set_option(buffer, 'bufhidden', 'wipe')
-
-  table.insert(windows, new_window)
-
-  logger.debug(vim.inspect({
-    windows = windows,
-    curr_window = vim.api.nvim_get_current_win(),
-    new_window = new_window,
-    bufpos = bufpos,
-    get_config = vim.api.nvim_win_get_config(new_window),
-    get_current_line = vim.api.nvim_get_current_line()
-  }))
-
-  vim.cmd[[
-    augroup close_float
-      au!
-      au WinClosed * lua require('goto-preview').remove_curr_win()
-    augroup end
-  ]]
-
-  M.run_hook_function(buffer, new_window)
-
-  vim.api.nvim_win_set_cursor(new_window, position)
-end
-
-M.run_hook_function = function(buffer, new_window)
-  local success, result = pcall(M.conf.post_open_hook, buffer, new_window)
-  logger.debug("post_open_hook call success:", success, result)
-end
-
-local function open_references_previewer(prompt_title, items)
-  local opts = M.conf.references.telescope
-  local entry_maker = make_entry.gen_from_quickfix(opts)
-  local previewer = nil
-
-  if not opts.hide_preview then
-    previewer = telescope_conf.qflist_previewer(opts)
-  end
-
-  pickers.new(opts, {
-    prompt_title = prompt_title,
-    finder = finders.new_table {
-      results = items,
-      entry_maker = entry_maker,
-    },
-    previewer = previewer,
-    sorter = telescope_conf.generic_sorter(opts),
-    attach_mappings = function(prompt_bufnr)
-      actions.select_default:replace(function()
-        local selection = action_state.get_selected_entry()
-        actions.close(prompt_bufnr)
-
-        local val = selection.value
-        open_floating_win(vim.uri_from_fname(val.filename), { val.lnum, val.col })
-      end)
-
-      return true
-    end,
-  }):find()
-end
-
-local handle = function(result)
-  if not result then return end
-
-  local data = result[1]
-
-  local target = nil
-  local cursor_position = {}
-
-  target, cursor_position = M.conf.lsp_configs.get_config(data)
-
-  open_floating_win(target, cursor_position)
-end
-
-local handle_references = function(result)
-  if not result then return end
-  local items = {}
-
-  vim.list_extend(items, vim.lsp.util.locations_to_items(result) or {})
-
-  open_references_previewer('References', items)
-end
-
-local legacy_handler = function(lsp_call)
-  return function(_, _, result)
-    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
-      handle_references(result)
-    else
-      handle(result)
-    end
-  end
-end
-
-local handler = function(lsp_call)
-  return function(_, result, _, _)
-    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
-      handle_references(result)
-    else
-      handle(result)
-    end
-  end
-end
-
-local get_handler = function(lsp_call)
-  -- Only really need to check one of the handlers
-  if debug.getinfo(vim.lsp.handlers['textDocument/definition']).nparams == 4 then
-    return handler(lsp_call)
-  else
-    return legacy_handler(lsp_call)
   end
 end
 
@@ -190,40 +41,40 @@ end
 M.lsp_request_definition = function()
   local params = vim.lsp.util.make_position_params()
   local lsp_call = "textDocument/definition"
-  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler())
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler())
   if not success then print_lsp_error(lsp_call) end
 end
 
 M.lsp_request_implementation = function()
   local params = vim.lsp.util.make_position_params()
   local lsp_call = "textDocument/implementation"
-  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler())
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler())
   if not success then print_lsp_error(lsp_call) end
 end
 
 M.lsp_request_references = function()
   local params = vim.lsp.util.make_position_params()
   local lsp_call = "textDocument/references"
-  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler(lsp_call))
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call))
   if not success then print_lsp_error(lsp_call) end
 end
 
 M.close_all_win = function()
-  for index = #windows, 1, -1 do
-    local window = windows[index]
+  for index = #lib.windows, 1, -1 do
+    local window = lib.windows[index]
     pcall(vim.api.nvim_win_close, window, true)
   end
 end
 
 M.remove_curr_win = function()
-  local index = tablefind(windows, vim.api.nvim_get_current_win())
+  local index = lib.tablefind(lib.windows, vim.api.nvim_get_current_win())
   if index then
-    table.remove(windows, index)
+    table.remove(lib.windows, index)
   end
 end
 
 M.goto_preview_definition = M.lsp_request_definition
-M.goto_preview_implementation = M.lsp_request_definition
+M.goto_preview_implementation = M.lsp_request_implementation
 M.goto_preview_references = M.lsp_request_references
 -- Mappings
 

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -1,3 +1,8 @@
+local pickers = require('telescope.pickers')
+local make_entry = require('telescope.make_entry')
+local conf = require('telescope.config').values
+local finders = require('telescope.finders')
+
 local M = {
   conf = {
     width = 120; -- Width of the floating window
@@ -12,6 +17,9 @@ local M = {
 
         return uri, { range.start.line +1, range.start.character }
       end;
+      -- get_references_config = function(data)
+      --   print('==== data', vim.inspect(data))
+      -- end
     };
     post_open_hook = nil -- A function taking two arguments, a buffer and a window to be ran as a hook.
   }
@@ -90,6 +98,40 @@ M.run_hook_function = function(buffer, new_window)
   logger.debug("post_open_hook call success:", success, result)
 end
 
+local function open_references_previewer(prompt_title, items, find_opts)
+  local opts = find_opts.opts or {
+    -- opts = opts.telescope,
+    entry_maker = function(line)
+      return {
+        valid = line ~= nil,
+        value = line,
+        ordinal = line.idx .. line.title,
+        display = string.format('%s%d: %s', '', line.idx, line.title),
+      }
+    end,
+    -- attach_mappings = attach_code_action_mappings,
+    hide_preview = false,
+  }
+
+  -- local entry_maker = find_opts.entry_maker or make_entry.gen_from_quickfix(opts)
+  -- local attach_mappings = find_opts.attach_mappings or attach_location_mappings
+  local previewer = nil
+  if not find_opts.hide_preview then
+    previewer = conf.qflist_previewer(opts)
+  end
+
+  pickers.new(opts, {
+    prompt_title = prompt_title,
+    finder = finders.new_table({
+      results = items,
+      -- entry_maker = entry_maker,
+    }),
+    previewer = previewer,
+    sorter = conf.generic_sorter(opts),
+    -- attach_mappings = attach_mappings,
+  }):find()
+end
+
 local handle = function(result)
   if not result then return end
 
@@ -103,39 +145,74 @@ local handle = function(result)
   open_floating_win(target, cursor_position)
 end
 
-local legacy_handler = function(_, _, result)
-  handle(result)
+local handle_references = function(result)
+  if not result then return end
+  print('==== results', vim.inspect(result))
+  local sanitized_list = {}
+
+  -- for data in pairs(result) do
+  --   local target, cursor_position = M.conf.lsp_configs.get_config(data)
+  --   table.insert(sanitized_list, {target=target, cursor_position=cursor_position})
+  -- end
+
+  -- Error executing vim.schedule lua callback: ...k/packer/opt/telescope.nvim/lua/telescope/make_entry.lua:317: attempt to concatenate field 'text' (a nil value)
+  -- Fiture out how to preview the pickers correctly
+  open_references_previewer('References', result, {})
 end
 
-local handler = function(_, result, _, _)
-  handle(result)
-end
-
-local get_handler = function()
-  -- Only really need to check one of the handlers
-  if debug.getinfo(vim.lsp.handlers['textDocument/definition']).nparams == 4 then
-    return handler
-  else
-    return legacy_handler
-  end
-end
-
-M.lsp_request = function(definition)
-  return function()
-    local params = vim.lsp.util.make_position_params()
-
-    if definition then
-      local success, _ = pcall(vim.lsp.buf_request, 0, "textDocument/definition", params, get_handler())
-      if not success then
-        print('goto-preview: Error calling LSP "textDocument/definition". The current language lsp might not support it.')
-      end
+local legacy_handler = function(lsp_call)
+  return function(_, _, result)
+    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
+      handle_references(result)
     else
-      local success, _ = pcall(vim.lsp.buf_request, 0, "textDocument/implementation", params, get_handler())
-      if not success then
-        print('goto-preview: Error calling LSP "textDocument/implementation". The current language lsp might not support it.')
-      end
+      handle(result)
     end
   end
+end
+
+local handler = function(lsp_call)
+  return function(_, result, _, _)
+    print('==== lsp_call', lsp_call)
+    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
+      handle_references(result)
+    else
+      handle(result)
+    end
+  end
+end
+
+local get_handler = function(lsp_call)
+  -- Only really need to check one of the handlers
+  if debug.getinfo(vim.lsp.handlers['textDocument/definition']).nparams == 4 then
+    return handler(lsp_call)
+  else
+    return legacy_handler(lsp_call)
+  end
+end
+
+local function print_lsp_error(lsp_call)
+  print('goto-preview: Error calling LSP' + lsp_call + '. The current language lsp might not support it.')
+end
+
+M.lsp_request_definition = function()
+  local params = vim.lsp.util.make_position_params()
+  local lsp_call = "textDocument/definition"
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler())
+  if not success then print_lsp_error(lsp_call) end
+end
+
+M.lsp_request_implementation = function()
+  local params = vim.lsp.util.make_position_params()
+  local lsp_call = "textDocument/implementation"
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler())
+  if not success then print_lsp_error(lsp_call) end
+end
+
+M.lsp_request_references = function()
+  local params = vim.lsp.util.make_position_params()
+  local lsp_call = "textDocument/references"
+  local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, get_handler(lsp_call))
+  if not success then print_lsp_error(lsp_call) end
 end
 
 M.close_all_win = function()
@@ -152,8 +229,9 @@ M.remove_curr_win = function()
   end
 end
 
-M.goto_preview_definition = M.lsp_request(true)
-M.goto_preview_implementation = M.lsp_request(false)
+M.goto_preview_definition = M.lsp_request_definition
+M.goto_preview_implementation = M.lsp_request_definition
+M.goto_preview_references = M.lsp_request_references
 -- Mappings
 
 M.apply_default_mappings = function()
@@ -171,9 +249,10 @@ M.apply_default_mappings = function()
     --   vimp.nnoremap('<up>', '<C-w>-')
     --   vimp.nnoremap('<down>', '<C-w>+')
     -- else
-      vim.api.nvim_set_keymap("n", "gpd", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
-      vim.api.nvim_set_keymap("n", "gpi", "<cmd>lua require('goto-preview').goto_preview_implementation()<CR>", {noremap=true})
-      vim.api.nvim_set_keymap("n", "gP", "<cmd>lua require('goto-preview').close_all_win()<CR>", {noremap=true})
+    vim.api.nvim_set_keymap("n", "gpd", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
+    vim.api.nvim_set_keymap("n", "gpi", "<cmd>lua require('goto-preview').goto_preview_implementation()<CR>", {noremap=true})
+    vim.api.nvim_set_keymap("n", "gpr", "<cmd>lua require('goto-preview').goto_preview_references()<CR>", {noremap=true})
+    vim.api.nvim_set_keymap("n", "gP", "<cmd>lua require('goto-preview').close_all_win()<CR>", {noremap=true})
     -- end
   end
 end

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -90,7 +90,6 @@ local open_floating_win = function(target, position)
 
   M.run_hook_function(buffer, new_window)
 
-  print('==== new_window, position', vim.inspect(new_window), vim.inspect(position))
   vim.api.nvim_win_set_cursor(new_window, position)
 end
 

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -224,25 +224,16 @@ M.goto_preview_references = M.lsp_request_references
 -- Mappings
 
 M.apply_default_mappings = function()
-  local has_vimp, vimp = pcall(require, "vimp")
   if M.conf.default_mappings then
-    -- if has_vimp then
-    --   vimp.unmap_all()
-    --   vimp.nnoremap('gpi', M.lsp_request(false))
-    --   vimp.nnoremap('gpd', M.lsp_request(true))
-    --   vimp.nnoremap('gP', M.close_all_win)
-
-    --   -- Resize windows
-    --   vimp.nnoremap('<left>', '<C-w><')
-    --   vimp.nnoremap('<right>', '<C-w>>')
-    --   vimp.nnoremap('<up>', '<C-w>-')
-    --   vimp.nnoremap('<down>', '<C-w>+')
-    -- else
     vim.api.nvim_set_keymap("n", "gpd", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
     vim.api.nvim_set_keymap("n", "gpi", "<cmd>lua require('goto-preview').goto_preview_implementation()<CR>", {noremap=true})
     vim.api.nvim_set_keymap("n", "gpr", "<cmd>lua require('goto-preview').goto_preview_references()<CR>", {noremap=true})
     vim.api.nvim_set_keymap("n", "gP", "<cmd>lua require('goto-preview').close_all_win()<CR>", {noremap=true})
-    -- end
+
+    vim.api.nvim_set_keymap('n', '<left>', '<C-w><', {noremap=true})
+    vim.api.nvim_set_keymap('n', '<right>', '<C-w>>', {noremap=true})
+    vim.api.nvim_set_keymap('n', '<up>', '<C-w>-', {noremap=true})
+    vim.api.nvim_set_keymap('n', '<down>', '<C-w>+', {noremap=true})
   end
 end
 

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -1,0 +1,163 @@
+local pickers = require('telescope.pickers')
+local make_entry = require('telescope.make_entry')
+local telescope_conf = require('telescope.config').values
+local finders = require('telescope.finders')
+local actions = require('telescope.actions')
+local action_state = require('telescope.actions.state')
+
+local M = {
+  conf = {}
+}
+
+M.setup_lib = function(conf)
+  M.conf = vim.tbl_extend('force', M.conf, conf)
+end
+
+local logger = {
+  debug = function(...)
+    if M.conf.debug then
+      print("goto-preview:", ...)
+    end
+  end
+}
+
+M.logger = logger
+M.tablefind = function(tab,el)
+  for index, value in pairs(tab) do
+    if value == el then
+      return index
+    end
+  end
+end
+
+local windows = {}
+M.windows = windows
+
+local run_hook_function = function(buffer, new_window)
+  local success, result = pcall(M.conf.post_open_hook, buffer, new_window)
+  logger.debug("post_open_hook call success:", success, result)
+end
+
+local open_floating_win = function(target, position)
+  local buffer = vim.uri_to_bufnr(target)
+  local bufpos = { vim.fn.line(".")-1, vim.fn.col(".") } -- FOR relative='win'
+  local zindex = vim.tbl_isempty(windows) and 1 or #windows+1
+  local new_window = vim.api.nvim_open_win(buffer, true, {
+    relative='win',
+    width=M.conf.width,
+    height=M.conf.height,
+    border={"↖", "─" ,"┐", "│", "┘", "─", "└", "│"},
+    bufpos=bufpos,
+    zindex=zindex,
+    win=vim.api.nvim_get_current_win()
+  })
+
+  if M.conf.opacity then vim.api.nvim_win_set_option(new_window, "winblend", M.conf.opacity) end
+  vim.api.nvim_buf_set_option(buffer, 'bufhidden', 'wipe')
+
+  table.insert(windows, new_window)
+
+  logger.debug(vim.inspect({
+    windows = windows,
+    curr_window = vim.api.nvim_get_current_win(),
+    new_window = new_window,
+    bufpos = bufpos,
+    get_config = vim.api.nvim_win_get_config(new_window),
+    get_current_line = vim.api.nvim_get_current_line()
+  }))
+
+  vim.cmd[[
+    augroup close_float
+      au!
+      au WinClosed * lua require('goto-preview').remove_curr_win()
+    augroup end
+  ]]
+
+  run_hook_function(buffer, new_window)
+
+  vim.api.nvim_win_set_cursor(new_window, position)
+end
+
+local function open_references_previewer(prompt_title, items)
+  local opts = M.conf.references.telescope
+  local entry_maker = make_entry.gen_from_quickfix(opts)
+  local previewer = nil
+
+  if not opts.hide_preview then
+    previewer = telescope_conf.qflist_previewer(opts)
+  end
+
+  pickers.new(opts, {
+    prompt_title = prompt_title,
+    finder = finders.new_table {
+      results = items,
+      entry_maker = entry_maker,
+    },
+    previewer = previewer,
+    sorter = telescope_conf.generic_sorter(opts),
+    attach_mappings = function(prompt_bufnr)
+      actions.select_default:replace(function()
+        local selection = action_state.get_selected_entry()
+        actions.close(prompt_bufnr)
+
+        local val = selection.value
+        open_floating_win(vim.uri_from_fname(val.filename), { val.lnum, val.col })
+      end)
+
+      return true
+    end,
+  }):find()
+end
+
+local handle = function(result)
+  if not result then return end
+
+  local data = result[1]
+
+  local target = nil
+  local cursor_position = {}
+
+  target, cursor_position = M.conf.lsp_configs.get_config(data)
+
+  open_floating_win(target, cursor_position)
+end
+
+local handle_references = function(result)
+  if not result then return end
+  local items = {}
+
+  vim.list_extend(items, vim.lsp.util.locations_to_items(result) or {})
+
+  open_references_previewer('References', items)
+end
+
+local legacy_handler = function(lsp_call)
+  return function(_, _, result)
+    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
+      handle_references(result)
+    else
+      handle(result)
+    end
+  end
+end
+
+local handler = function(lsp_call)
+  return function(_, result, _, _)
+    if lsp_call ~= nil and lsp_call == 'textDocument/references' then
+      handle_references(result)
+    else
+      handle(result)
+    end
+  end
+end
+
+M.get_handler = function(lsp_call)
+  -- Only really need to check one of the handlers
+  if debug.getinfo(vim.lsp.handlers['textDocument/definition']).nparams == 4 then
+    return handler(lsp_call)
+  else
+    return legacy_handler(lsp_call)
+  end
+end
+
+return M

--- a/lua/telescope/_extensions/gotopreview.lua
+++ b/lua/telescope/_extensions/gotopreview.lua
@@ -1,0 +1,14 @@
+local has_telescope, telescope = pcall(require, "telescope")
+local GotoPreview = require('goto-preview')
+
+
+if not has_telescope then
+  error("This plugin requires telescope.nvim (https://github.com/nvim-telescope/telescope.nvim)")
+end
+
+return telescope.register_extension {
+  setup = GotoPreview.setup,
+  exports = {
+    references = GotoPreview.goto_preview_references
+  }
+}


### PR DESCRIPTION
Added support for LSP References preview calls.
One can now cycle between references through the use of [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
Upon selection a preview window of the reference is triggered.

https://user-images.githubusercontent.com/2881382/133213596-b5795cd9-c84f-4561-bf66-49ea65b7c48b.mp4

