### PR TITLE
Fix post_open_hook

### DIFF
--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -28,6 +28,7 @@ M.setup = function(conf)
   M.conf = vim.tbl_deep_extend('force', M.conf, conf)
   lib.logger.debug('non-lib:', vim.inspect(M.conf))
   lib.setup_lib(M.conf)
+  lib.setup_aucmds()
 
   if M.conf.default_mappings then M.apply_default_mappings() end
   if M.conf.resizing_mappings then M.apply_resizing_mappings() end
@@ -74,6 +75,7 @@ M.close_all_win = function()
 end
 
 M.remove_curr_win = lib.remove_curr_win
+M.buffer_entered = lib.buffer_entered
 M.goto_preview_definition = M.lsp_request_definition
 M.goto_preview_implementation = M.lsp_request_implementation
 M.goto_preview_references = M.lsp_request_references


### PR DESCRIPTION
The hook was not being called if one navigated into a definition that
the source was in a different file, hence triggering an opening of a new
buffer. That new buffer would not have the hook function called on it,
even if it was originally opened from a goto-preview window.

This commit:
- Changes how autocmd is setup. i.e setting it up only once now, not
  once per call.
- Adds a BufEnter autocmd for goto-preview that checks if the opened
  buffer's window is a goto-preview window, if it is, runs the hooks
  just like it would previously for a goto-preview open floating window
  call.

Closes #17.