### PR TITLE
Fix not passing a context on the references call

### DIFF
--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -77,6 +77,15 @@ end
 
 M.lsp_request_references = function(opts)
   local params = vim.lsp.util.make_position_params()
+
+  lib.logger.debug("params pre manipulation", vim.inspect(params))
+  if not params.context then
+    params.context = {
+      includeDeclaration = true,
+    }
+  end
+  lib.logger.debug("params post manipulation", vim.inspect(params))
+
   local lsp_call = "textDocument/references"
   local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call, opts))
   if not success then


### PR DESCRIPTION
Neovim's builtin client actually adds the `context.includeDeclaration = true` in its call, I'm doing the raw call myself, bypassing what the builtin client does by default, hence the issue.

Ref:
https://github.com/neovim/neovim/blob/1f3c0593eb1d4e54ce1edf35da67d184807a9280/runtime/lua/vim/lsp/buf.lua#L314

Closes #50