### PR TITLE
Fix warning with locations_to_items

### DIFF
--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -234,7 +234,7 @@ local handle_references = function(result)
   end
   local items = {}
 
-  vim.list_extend(items, vim.lsp.util.locations_to_items(result) or {})
+  vim.list_extend(items, vim.lsp.util.locations_to_items(result, "utf-8") or {})
 
   open_references_previewer("References", items)
 end


### PR DESCRIPTION
Without this change, I get this warning: `locations_to_items must be called with valid offset encoding`
It's probably not safe to assume utf-8 all the time, so if you have a better way to derive the encoding, that should probably be used instead.