### PR TITLE
feat: Add option for whether to nest floating windows or not

### DIFF
--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -27,6 +27,7 @@ local M = {
     dismiss_on_move = false, -- Dismiss the floating window when moving the cursor.
     force_close = true, -- passed into vim.api.nvim_win_close's second argument. See :h nvim_win_close
     bufhidden = "wipe", -- the bufhidden option to set on the floating window. See :h bufhidden
+    nest_floating = true, -- Whether to nest floating windows
   },
 }
 

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -35,6 +35,10 @@ M.setup_lib = function(conf)
   M.logger.debug("lib:", vim.inspect(M.conf))
 end
 
+local function is_floating(window_id)
+  return vim.api.nvim_win_get_config(window_id).relative ~= ''
+end
+
 local logger = {
   debug = function(...)
     if M.conf.debug then
@@ -111,32 +115,53 @@ M.open_floating_win = function(target, position, opts)
     end
   end
 
-  logger.debug("focus_on_open", enter())
-  local new_window = vim.api.nvim_open_win(buffer, enter(), {
-    relative = "win",
-    width = M.conf.width,
-    height = M.conf.height,
-    border = M.conf.border,
-    bufpos = bufpos,
-    zindex = zindex,
-    win = vim.api.nvim_get_current_win(),
-  })
+  local nest_floating = function()
+    if opts.nest_floating ~= nil then
+      return opts.nest_floating
+    else
+      return M.conf.nest_floating
+    end
+  end
 
-  table.insert(M.windows, new_window)
+  logger.debug("focus_on_open", enter())
+  logger.debug("nest_floating", nest_floating())
+  local curr_win = vim.api.nvim_get_current_win()
+  local preview_window = {}
+  if not nest_floating() and is_floating(curr_win) then
+    preview_window = curr_win
+    vim.api.nvim_win_set_config(preview_window, {
+      width = M.conf.width,
+      height = M.conf.height,
+      border = M.conf.border,
+    })
+    vim.api.nvim_win_set_buf(preview_window, buffer)
+  else
+    preview_window = vim.api.nvim_open_win(buffer, enter(), {
+      relative = "win",
+      width = M.conf.width,
+      height = M.conf.height,
+      border = M.conf.border,
+      bufpos = bufpos,
+      zindex = zindex,
+      win = vim.api.nvim_get_current_win(),
+    })
+
+    table.insert(M.windows, preview_window)
+  end
 
   if M.conf.opacity then
-    vim.api.nvim_win_set_option(new_window, "winblend", M.conf.opacity)
+    vim.api.nvim_win_set_option(preview_window, "winblend", M.conf.opacity)
   end
   if vim.api.nvim_get_current_buf() ~= buffer then
     vim.api.nvim_buf_set_option(buffer, "bufhidden", M.conf.bufhidden)
   end
-  vim.api.nvim_win_set_var(new_window, "is-goto-preview-window", 1)
+  vim.api.nvim_win_set_var(preview_window, "is-goto-preview-window", 1)
 
   logger.debug(vim.inspect {
     curr_window = vim.api.nvim_get_current_win(),
-    new_window = new_window,
+    preview_window = preview_window,
     bufpos = bufpos,
-    get_config = vim.api.nvim_win_get_config(new_window),
+    get_config = vim.api.nvim_win_get_config(preview_window),
     get_current_line = vim.api.nvim_get_current_line(),
     windows = M.windows,
   })
@@ -152,14 +177,14 @@ M.open_floating_win = function(target, position, opts)
   logger.debug("dismiss_on_move", dismiss())
   if dismiss() then
     vim.api.nvim_command(
-      string.format("autocmd CursorMoved <buffer> ++once lua require('goto-preview').dismiss_preview(%d)", new_window)
+      string.format("autocmd CursorMoved <buffer> ++once lua require('goto-preview').dismiss_preview(%d)", preview_window)
     )
   end
 
   -- Set position of the preview buffer equal to the target position so that correct preview position shows
-  vim.api.nvim_win_set_cursor(new_window, position)
+  vim.api.nvim_win_set_cursor(preview_window, position)
 
-  run_hook_function(buffer, new_window)
+  run_hook_function(buffer, preview_window)
 end
 
 M.buffer_entered = function()


### PR DESCRIPTION
I've added a boolean option `nest_floating` to chose whether to allow for multiple nested floating windows to be opened. `true` is the current default behavior and `false` changes it. If `false` and the current window is floating, then it will reuse the current floating window, otherwise it'll open up a floating window like normal.

Use Case: I work with C quite a bit and when I initially use goto-definition, I get the function _signature_ in a header file. 99.9% of the time, I don't care about that, so I have to use goto-definition again to get to the actual function definition. I'd like the option of not having two floating windows cluttering up the screen when I don't want to. Conversely, I would like a floating window if I've taken a preview window and moved it into a "real" window. 

Code Note:
- I'm open to other opinions on the option name. Maybe `stack_floating` is better since the preview windows are nested inside each other, but just stacked.
- I've gone ahead a refactored `new_window` to `preview_window` to reflect the fact that the preview window might not always be new with this feature addition.