### PR TITLE
docs: ensure default config works if copied

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ require('goto-preview').setup {
   resizing_mappings = false; -- Binds arrow keys to resizing the floating window.
   post_open_hook = nil; -- A function taking two arguments, a buffer and a window to be ran as a hook.
   references = { -- Configure the telescope UI for slowing the references cycling window.
-    telescope = telescope.themes.get_dropdown({ hide_preview = false })
+    telescope = require("telescope.themes").get_dropdown({ hide_preview = false })
   };
   -- These two configs can also be passed down to the goto-preview definition and implementation calls for one off "peak" functionality.
   focus_on_open = true; -- Focus the floating window when opening it.


### PR DESCRIPTION
## Summary

Cleans up the documentation so copy and pasting the default configuration doesn't throw errors