### PR TITLE
Isolate telescope delendency to the open_references_previewer call

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,13 +66,12 @@ nnoremap gpd <cmd>lua require('goto-preview').goto_preview_definition()<CR>
 nnoremap gpt <cmd>lua require('goto-preview').goto_preview_type_definition()<CR>
 nnoremap gpi <cmd>lua require('goto-preview').goto_preview_implementation()<CR>
 nnoremap gP <cmd>lua require('goto-preview').close_all_win()<CR>
-" Only set if you have telescope installed
 nnoremap gpr <cmd>lua require('goto-preview').goto_preview_references()<CR>
 ```
 
 **Custom example**
 ```lua
-vim.api.nvim_set_keymap("n", "gp", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
+vim.keymap.set("n", "gp", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
 ```
 
 ### Window manipulation

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -21,7 +21,7 @@ local M = {
     },
     post_open_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
     references = {
-      telescope = lib.has_telescope and lib.telescope.themes.get_dropdown { hide_preview = false } or nil,
+      telescope = nil,
     },
     focus_on_open = true, -- Focus the floating window when opening it.
     dismiss_on_move = false, -- Dismiss the floating window when moving the cursor.
@@ -130,42 +130,20 @@ M.goto_preview_references = M.lsp_request_references
 
 M.apply_default_mappings = function()
   if M.conf.default_mappings then
-    vim.api.nvim_set_keymap(
-      "n",
-      "gpd",
-      "<cmd>lua require('goto-preview').goto_preview_definition()<CR>",
-      { noremap = true }
-    )
-    vim.api.nvim_set_keymap(
-      "n",
-      "gpt",
-      "<cmd>lua require('goto-preview').goto_preview_type_definition()<CR>",
-      { noremap = true }
-    )
-    vim.api.nvim_set_keymap(
-      "n",
-      "gpi",
-      "<cmd>lua require('goto-preview').goto_preview_implementation()<CR>",
-      { noremap = true }
-    )
-    if lib.has_telescope then
-      vim.api.nvim_set_keymap(
-        "n",
-        "gpr",
-        "<cmd>lua require('goto-preview').goto_preview_references()<CR>",
-        { noremap = true }
-      )
-    end
-    vim.api.nvim_set_keymap("n", "gP", "<cmd>lua require('goto-preview').close_all_win()<CR>", { noremap = true })
+    vim.keymap.set("n", "gpd", require("goto-preview").goto_preview_definition)
+    vim.keymap.set("n", "gpt", require("goto-preview").goto_preview_type_definition)
+    vim.keymap.set("n", "gpi", require("goto-preview").goto_preview_implementation)
+    vim.keymap.set("n", "gpr", require("goto-preview").goto_preview_references)
+    vim.keymap.set("n", "gP", require("goto-preview").close_all_win)
   end
 end
 
 M.apply_resizing_mappings = function()
   if M.conf.resizing_mappings then
-    vim.api.nvim_set_keymap("n", "<left>", "<C-w><", { noremap = true })
-    vim.api.nvim_set_keymap("n", "<right>", "<C-w>>", { noremap = true })
-    vim.api.nvim_set_keymap("n", "<up>", "<C-w>-", { noremap = true })
-    vim.api.nvim_set_keymap("n", "<down>", "<C-w>+", { noremap = true })
+    vim.keymap.set("n", "<left>", "<C-w><", { noremap = true })
+    vim.keymap.set("n", "<right>", "<C-w>>", { noremap = true })
+    vim.keymap.set("n", "<up>", "<C-w>-", { noremap = true })
+    vim.keymap.set("n", "<down>", "<C-w>+", { noremap = true })
   end
 end
 

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -1,33 +1,5 @@
-local has_telescope = pcall(require, "telescope")
-
-local pickers
-local make_entry
-local telescope_conf
-local finders
-local actions
-local action_state
-local themes
-
-local function init_telescope()
-  pickers = require "telescope.pickers"
-  make_entry = require "telescope.make_entry"
-  telescope_conf = require("telescope.config").values
-  finders = require "telescope.finders"
-  actions = require "telescope.actions"
-  action_state = require "telescope.actions.state"
-  themes = require "telescope.themes"
-end
-
-if has_telescope then
-  init_telescope()
-end
-
 local M = {
   conf = {},
-  has_telescope = has_telescope,
-  telescope = has_telescope and {
-    themes = themes,
-  } or nil,
 }
 
 M.setup_lib = function(conf)
@@ -36,7 +8,7 @@ M.setup_lib = function(conf)
 end
 
 local function is_floating(window_id)
-  return vim.api.nvim_win_get_config(window_id).relative ~= ''
+  return vim.api.nvim_win_get_config(window_id).relative ~= ""
 end
 
 local logger = {
@@ -126,7 +98,7 @@ M.open_floating_win = function(target, position, opts)
   logger.debug("focus_on_open", enter())
   logger.debug("stack_floating_preview_windows", stack_floating_preview_windows())
 
-  local preview_window = {}
+  local preview_window
   local curr_win = vim.api.nvim_get_current_win()
   local success, result = pcall(vim.api.nvim_win_get_var, curr_win, "is-goto-preview-window")
   if not stack_floating_preview_windows() and is_floating(curr_win) and success and result == 1 then
@@ -179,7 +151,10 @@ M.open_floating_win = function(target, position, opts)
   logger.debug("dismiss_on_move", dismiss())
   if dismiss() then
     vim.api.nvim_command(
-      string.format("autocmd CursorMoved <buffer> ++once lua require('goto-preview').dismiss_preview(%d)", preview_window)
+      string.format(
+        "autocmd CursorMoved <buffer> ++once lua require('goto-preview').dismiss_preview(%d)",
+        preview_window
+      )
     )
   end
 
@@ -206,8 +181,18 @@ local function _open_references_window(val)
 end
 
 local function open_references_previewer(prompt_title, items)
+  local has_telescope, _ = pcall(require, "telescope")
+
   if has_telescope then
-    local opts = M.conf.references.telescope
+    local pickers = require "telescope.pickers"
+    local make_entry = require "telescope.make_entry"
+    local telescope_conf = require("telescope.config").values
+    local finders = require "telescope.finders"
+    local actions = require "telescope.actions"
+    local action_state = require "telescope.actions.state"
+    local themes = require "telescope.themes"
+
+    local opts = M.conf.references.telescope or themes.get_dropdown { hide_preview = false }
     local entry_maker = make_entry.gen_from_quickfix(opts)
     local previewer = nil
 


### PR DESCRIPTION
Closes #81

This commit also stops using `vim.api.nvim_set_keymap` in favour of `vim.keymap.set` for setting mappings.