### PR TITLE
Add `skip_curr_window` option to `close_all_win` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ nnoremap gpr <cmd>lua require('goto-preview').goto_preview_references()<CR>
 vim.keymap.set("n", "gp", "<cmd>lua require('goto-preview').goto_preview_definition()<CR>", {noremap=true})
 ```
 
+### 📚 Custom Options
+
+The `close_all_win` function takes an optional table as an argument.
+
+Example usage:
+```lua
+require("goto-preview").close_all_win { skip_curr_window = true }
+```
+
 ### Window manipulation
 One can manipulate floating windows with the regular Vim window moving commands. See `:h window-moving`.
 Example:

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -110,12 +110,20 @@ M.lsp_request_references = function(opts)
   end
 end
 
-M.close_all_win = function()
+M.close_all_win = function(options)
   local windows = vim.api.nvim_tabpage_list_wins(0)
+
   for _, win in pairs(windows) do
     local index = lib.tablefind(lib.windows, win)
     table.remove(lib.windows, index)
-    pcall(lib.close_if_is_goto_preview, win)
+
+    if options and options.skip_curr_window then
+      if win ~= vim.api.nvim_get_current_win() then
+        pcall(lib.close_if_is_goto_preview, win)
+      end
+    else
+      pcall(lib.close_if_is_goto_preview, win)
+    end
   end
 end
 

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -50,7 +50,7 @@ M.setup_aucmds = function()
       au WinClosed * lua require('goto-preview').remove_win()
       au BufEnter * lua require('goto-preview').buffer_entered()
     augroup end
-    ]]
+  ]]
 end
 
 M.dismiss_preview = function(winnr)


### PR DESCRIPTION
Usage:
```lua
  require("goto-preview").close_all_win { skip_curr_window = true }
```

This option does as expected, skips the current window when closing all the preview windows.