### PR TITLE
Add options for customizing preview window title and position.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ require('goto-preview').setup {
   dismiss_on_move = false; -- Dismiss the floating window when moving the cursor.
   force_close = true, -- passed into vim.api.nvim_win_close's second argument. See :h nvim_win_close
   bufhidden = "wipe", -- the bufhidden option to set on the floating window. See :h bufhidden
+  stack_floating_preview_windows = true, -- Whether to nest floating windows
+  preview_window_title = { enable = true, position = "left" }, -- Whether to set the preview window title as the filename
 }
 ```
 

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -9,7 +9,8 @@ local M = {
     resizing_mappings = false, -- Binds arrow keys to resizing the floating window.
     debug = false, -- Print debug information
     opacity = nil, -- 0-100 opacity level of the floating window where 100 is fully transparent.
-    lsp_configs = { -- Lsp result configs
+    lsp_configs = {
+      -- Lsp result configs
       get_config = function(data)
         lib.logger.debug("data from the lsp", vim.inspect(data))
 
@@ -28,6 +29,7 @@ local M = {
     force_close = true, -- passed into vim.api.nvim_win_close's second argument. See :h nvim_win_close
     bufhidden = "wipe", -- the bufhidden option to set on the floating window. See :h bufhidden
     stack_floating_preview_windows = true, -- Whether to nest floating windows
+    preview_window_title = { enable = true, position = "left" }, -- Whether to set the preview window title as the filename
   },
 }
 
@@ -139,8 +141,15 @@ M.goto_preview_references = M.lsp_request_references
 M.apply_default_mappings = function()
   if M.conf.default_mappings then
     vim.keymap.set("n", "gpd", require("goto-preview").goto_preview_definition, { desc = "Preview definition" })
-    vim.keymap.set("n", "gpt", require("goto-preview").goto_preview_type_definition, { desc = "Preview type definition" })
-    vim.keymap.set("n", "gpi", require("goto-preview").goto_preview_implementation, { desc = "Preview implementation" })
+    vim.keymap.set(
+      "n",
+      "gpt",
+      require("goto-preview").goto_preview_type_definition,
+      { desc = "Preview type definition" }
+    )
+    vim.keymap.set("n", "gpi", require("goto-preview").goto_preview_implementation, {
+      desc = "Preview implementation",
+    })
     vim.keymap.set("n", "gpr", require("goto-preview").goto_preview_references, { desc = "Preview references" })
     vim.keymap.set("n", "gP", require("goto-preview").close_all_win, { desc = "Close preview windows" })
   end

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -110,6 +110,8 @@ M.open_floating_win = function(target, position, opts)
     })
     vim.api.nvim_win_set_buf(preview_window, buffer)
   else
+    local rel_filepath = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(buffer), ":.")
+
     preview_window = vim.api.nvim_open_win(buffer, enter(), {
       relative = "win",
       width = M.conf.width,
@@ -118,6 +120,8 @@ M.open_floating_win = function(target, position, opts)
       bufpos = bufpos,
       zindex = zindex,
       win = vim.api.nvim_get_current_win(),
+      title = M.conf.preview_window_title.enable and rel_filepath or nil,
+      title_pos = M.conf.preview_window_title.enable and M.conf.preview_window_title.position or nil,
     })
 
     table.insert(M.windows, preview_window)


### PR DESCRIPTION
Adds file path and title position to the floating window title if enabled

[README.md]
- Add options for stacking floating preview windows
- Add option for setting the preview window title as the filename [lua/goto-preview/lib.lua]
- Add the file path to the floating window title if enabled
- Add the title position to the floating window if enabled [lua/goto-preview.lua]
- Add a `preview_window_title` configuration option
- Reformat `get_config` function in `lsp_configs`

Closes #92