### PR TITLE
fix: Add case where post_close_hook should run

### DIFF
--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -40,6 +40,15 @@ function M.tablefind(tab, el)
 end
 
 M.remove_win = function(win)
+  local curr_buf = vim.api.nvim_get_current_buf()
+  local curr_win = vim.api.nvim_get_current_win()
+
+  local success, result = pcall(vim.api.nvim_win_get_var, curr_win, "is-goto-preview-window")
+
+  if success and result == 1 then
+    run_post_close_hook_function(curr_buf, curr_win)
+  end
+
   local index = M.tablefind(M.windows, win or vim.api.nvim_get_current_win())
   if index then
     table.remove(M.windows, index)


### PR DESCRIPTION
Hey I just discovered a case where the post_close_hook doesn't execute and it should. You can test this out by opening a floating window preview in the current buffer. For example you're in file.py and the definition that you want to go to is also in file.py the post close hook won't execute after closing the preview window. Sorry I missed this case in my previous pull request! This fixes it.

If there's any implementation changes you'd prefer or formatting please let me know!