### PR TITLE
docs: added same_file_float_preview option

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ require('goto-preview').setup {
   force_close = true, -- passed into vim.api.nvim_win_close's second argument. See :h nvim_win_close
   bufhidden = "wipe", -- the bufhidden option to set on the floating window. See :h bufhidden
   stack_floating_preview_windows = true, -- Whether to nest floating windows
+  same_file_float_preview = true, -- Whether to open a new floating window for a reference within the current file
   preview_window_title = { enable = true, position = "left" }, -- Whether to set the preview window title as the filename
   zindex = 1, -- Starting zindex for the stack of floating windows
 }


### PR DESCRIPTION
Hi. Based on PR https://github.com/rmagatti/goto-preview/pull/110, we now have the `same_file_float_preview` option. I noticed there is no documentation for this option, especially in the README file, so with this PR i have added. You might also consider closing issue https://github.com/rmagatti/goto-preview/issues/59 by linking this PR or https://github.com/rmagatti/goto-preview/pull/110, cause i think it had solved. Thanks!