### PR TITLE
Add support for more picker providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ require('goto-preview').setup {
   post_open_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
   post_close_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
   references = { -- Configure the telescope UI for slowing the references cycling window.
+    provider = "telescope", -- telescope|fzf_lua|snacks|mini_pick|default
     telescope = require("telescope.themes").get_dropdown({ hide_preview = false })
   },
   -- These two configs can also be passed down to the goto-preview definition and implementation calls for one off "peak" functionality.

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -28,6 +28,7 @@ local M = {
     post_open_hook = nil,  -- A function taking two arguments, a buffer and a window to be ran as a hook.
     post_close_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
     references = {
+      provider = "telescope", -- telescope|fzf_lua|snacks|mini_pick|default
       telescope = nil,
     },
     focus_on_open = true,                                        -- Focus the floating window when opening it.


### PR DESCRIPTION
Closes #127. This adds support for [fzf-lua](https://github.com/ibhagwan/fzf-lua), [snacks.picker](https://github.com/folke/snacks.nvim), [mini.pick](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pick.md), or `vim.ui.select()` as a fallback. Unfortunately fzf-lua and snacks both call their own respective lsp-reference finder in this implementation, thus making unnecessary calls to the vim api. I did not find a trivial way to avoid this.