### PR TITLE
Implement vim UI input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,26 +17,10 @@ There is a bug in [Neovim `0.5`](https://github.com/neovim/neovim/issues/14735) 
 ```lua
 {
   "rmagatti/goto-preview",
+  dependencies = { "rmagatti/logger.nvim" },
   event = "BufEnter",
   config = true, -- necessary as per https://github.com/rmagatti/goto-preview/issues/88
 }
-```
-
-[Packer.nvim](https://github.com/wbthomason/packer.nvim)
-```lua
-use {
-  'rmagatti/goto-preview',
-  config = function()
-    require('goto-preview').setup {}
-  end
-}
-```
-[vim-plug](https://github.com/junegunn/vim-plug)
-```vim
-Plug 'rmagatti/goto-preview'
-
-" Then at some later point (outside of the plug block):
-:lua require('goto-preview').setup {}
 ```
 
 ### ⚙️ Configuration

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -39,7 +39,7 @@ local M = {
     same_file_float_preview = true,                              -- Whether to open a new floating window for a reference within the current file
     preview_window_title = { enable = true, position = "left" }, -- Whether to set the preview window title as the filename
     zindex = 1,                                                  -- Starting zindex for the stack of floating windows
-    custom_ui_input = true,                                     -- Whether to override vim.ui.input with our custom implementation
+    vim_ui_input = true,                                         -- Whether to override vim.ui.input with our custom implementation
   },
 }
 
@@ -58,7 +58,7 @@ M.setup = function(conf)
   end
 
   -- Setup custom input UI if enabled
-  if M.conf.custom_ui_input then
+  if M.conf.vim_ui_input then
     lib.setup_custom_input()
   end
 end

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -25,8 +25,8 @@ local M = {
         return uri, { range.start.line + 1, range.start.character }
       end,
     },
-    post_open_hook = nil,  -- A function taking two arguments, a buffer and a window to be ran as a hook.
-    post_close_hook = nil, -- A function taking two arguments, a buffer and a window to be ran as a hook.
+    post_open_hook = nil,     -- A function taking two arguments, a buffer and a window to be ran as a hook.
+    post_close_hook = nil,    -- A function taking two arguments, a buffer and a window to be ran as a hook.
     references = {
       provider = "telescope", -- telescope|fzf_lua|snacks|mini_pick|default
       telescope = nil,
@@ -39,6 +39,7 @@ local M = {
     same_file_float_preview = true,                              -- Whether to open a new floating window for a reference within the current file
     preview_window_title = { enable = true, position = "left" }, -- Whether to set the preview window title as the filename
     zindex = 1,                                                  -- Starting zindex for the stack of floating windows
+    custom_ui_input = true,                                     -- Whether to override vim.ui.input with our custom implementation
   },
 }
 
@@ -54,6 +55,11 @@ M.setup = function(conf)
   end
   if M.conf.resizing_mappings then
     M.apply_resizing_mappings()
+  end
+
+  -- Setup custom input UI if enabled
+  if M.conf.custom_ui_input then
+    lib.setup_custom_input()
   end
 end
 

--- a/lua/goto-preview.lua
+++ b/lua/goto-preview.lua
@@ -46,8 +46,8 @@ local M = {
 M.setup = function(conf)
   conf = conf or {}
   M.conf = vim.tbl_deep_extend("force", M.conf, conf)
-  lib.logger.debug("non-lib:", vim.inspect(M.conf))
   lib.setup_lib(M.conf)
+  lib.logger.debug("non-lib:", vim.inspect(M.conf))
   lib.setup_aucmds()
 
   if M.conf.default_mappings then
@@ -76,6 +76,7 @@ M.lsp_request_definition = function(opts)
   local params = vim.lsp.util.make_position_params(nil, get_offset_encoding())
   local lsp_call = "textDocument/definition"
   local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call, opts))
+  lib.logger.debug("lsp_request_definition", success)
   if not success then
     print_lsp_error(lsp_call)
   end
@@ -90,6 +91,7 @@ M.lsp_request_type_definition = function(opts)
   local params = vim.lsp.util.make_position_params(nil, get_offset_encoding())
   local lsp_call = "textDocument/typeDefinition"
   local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call, opts))
+  lib.logger.debug("lsp_request_type_definition", success)
   if not success then
     print_lsp_error(lsp_call)
   end
@@ -104,6 +106,7 @@ M.lsp_request_implementation = function(opts)
   local params = vim.lsp.util.make_position_params(nil, get_offset_encoding())
   local lsp_call = "textDocument/implementation"
   local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call, opts))
+  lib.logger.debug("lsp_request_implementation", success)
   if not success then
     print_lsp_error(lsp_call)
   end
@@ -118,6 +121,7 @@ M.lsp_request_declaration = function(opts)
   local params = vim.lsp.util.make_position_params(nil, get_offset_encoding())
   local lsp_call = "textDocument/declaration"
   local success, _ = pcall(vim.lsp.buf_request, 0, lsp_call, params, lib.get_handler(lsp_call, opts))
+  lib.logger.debug("lsp_request_declaration", success)
   if not success then
     print_lsp_error(lsp_call)
   end

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -43,6 +43,106 @@ function M.tablefind(tab, el)
   end
 end
 
+--- Setup the custom UI input functionality
+M.setup_custom_input = function()
+  -- Store the original vim.ui.input
+  M._original_input = vim.ui.input
+
+  -- Replace with our custom implementation
+  vim.ui.input = function(opts, on_confirm)
+    -- Create a new buffer for the input field
+    local buf = vim.api.nvim_create_buf(false, true)
+
+    -- Pre-populate with default text if provided
+    if opts.default then
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { opts.default })
+    else
+      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
+    end
+
+    -- Open the floating window using our existing function
+    local win = M.open_floating_win(buf, { 1, 0 }, {
+      focus_on_open = true,
+      dismiss_on_move = false,
+      -- Override some settings specific to input windows
+      same_file_float_preview = true
+    })
+
+    -- Move cursor to the end of any default text
+    local line_length = #(opts.default or "")
+    vim.api.nvim_win_set_cursor(win, { 1, line_length })
+
+    -- Set window title if we have a prompt
+    if vim.fn.has("nvim-0.9.0") == 1 and opts.prompt then
+      vim.api.nvim_win_set_config(win, {
+        title = opts.prompt,
+        title_pos = "left"
+      })
+    end
+
+    -- Function to handle result and clean up
+    local function handle_result(result)
+      -- Remove from windows table
+      local index = M.tablefind(M.windows, win)
+      if index then
+        table.remove(M.windows, index)
+      end
+
+      -- Run post close hook if defined
+      if M.conf.post_close_hook then
+        run_post_close_hook_function(buf, win)
+      end
+
+      -- Close the window
+      pcall(vim.api.nvim_win_close, win, true)
+
+      -- Call the callback
+      if on_confirm then
+        on_confirm(result)
+      end
+    end
+
+    -- Set keymaps for the input window
+    local keymaps = {
+      -- Normal mode mappings
+      n = {
+        ["<CR>"] = function()
+          local result = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+          handle_result(result)
+        end,
+        ["<Esc>"] = function()
+          handle_result(nil)
+        end,
+        ["i"] = function()
+          vim.cmd("startinsert")
+        end,
+        ["a"] = function()
+          vim.cmd("startinsert")
+        end,
+      },
+
+      -- Insert mode mappings
+      i = {
+        ["<CR>"] = function()
+          local result = vim.api.nvim_buf_get_lines(buf, 0, 1, false)[1]
+          handle_result(result)
+        end,
+      },
+    }
+
+    -- Apply all keymaps
+    for mode, maps in pairs(keymaps) do
+      for key, func in pairs(maps) do
+        vim.keymap.set(mode, key, func, { buffer = buf, nowait = true })
+      end
+    end
+
+    -- Start in normal mode by default
+    vim.cmd("stopinsert")
+    vim.notify("Press <CR> to confirm, <Esc> to cancel", "info")
+  end
+end
+
 M.remove_win = function(win)
   local curr_buf = vim.api.nvim_get_current_buf()
   local curr_win = vim.api.nvim_get_current_win()
@@ -219,6 +319,8 @@ M.open_floating_win = function(target, position, opts)
   vim.api.nvim_win_set_cursor(preview_window, position)
 
   run_post_open_hook_function(buffer, preview_window)
+
+  return preview_window
 end
 
 M.buffer_entered = function()
@@ -399,7 +501,7 @@ local providers = {
           return _format_item_entry(item)
         end
       end
-      }, function(choice)
+    }, function(choice)
       if choice ~= nil then
         _open_references_window(choice.filename, {
           choice.lnum,
@@ -492,8 +594,8 @@ M.get_handler = function(lsp_call, opts)
   -- Only really need to check one of the handlers
   for k, v in pairs(vim.lsp.handlers) do
     if string.find(k, "textDocument")
-      and type(v) == "function"
-      and debug.getinfo(v).isvararg == false
+        and type(v) == "function"
+        and debug.getinfo(v).isvararg == false
     then
       if debug.getinfo(v).nparams == 4 then
         logger.debug "calling new handler"

--- a/lua/goto-preview/lib.lua
+++ b/lua/goto-preview/lib.lua
@@ -2,9 +2,13 @@ local M = {
   conf = {},
 }
 
+logger = nil
+
 M.setup_lib = function(conf)
   M.conf = vim.tbl_deep_extend("force", M.conf, conf)
-  M.logger.debug("lib:", vim.inspect(M.conf))
+  logger = require("logger"):new({ log_level = M.conf.debug and "debug" or "info", prefix = "goto-preview" })
+  M.logger = logger
+  logger.debug("lib:", vim.inspect(M.conf))
 end
 
 local function is_floating(window_id)
@@ -15,15 +19,6 @@ local function is_curr_buf(buffer)
   return vim.api.nvim_get_current_buf() == buffer
 end
 
-local logger = {
-  debug = function(...)
-    if M.conf.debug then
-      print("goto-preview:", ...)
-    end
-  end,
-}
-
-M.logger = logger
 
 local run_post_open_hook_function = function(buffer, new_window)
   local success, result = pcall(M.conf.post_open_hook, buffer, new_window)
@@ -54,23 +49,28 @@ M.setup_custom_input = function()
     local buf = vim.api.nvim_create_buf(false, true)
 
     -- Pre-populate with default text if provided
-    if opts.default then
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { opts.default })
-    else
-      vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "" })
-    end
+    local initial_text = opts.default or ""
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { initial_text })
+
+    -- Calculate appropriate width based on content + padding
+    local content_width = #initial_text
+    local min_width = 20  -- Minimum width for small inputs
+    local max_width = 120 -- Maximum width to prevent too wide windows
+    local padding = 16    -- Extra space for cursor, line numbers, and comfort
+    local width = math.min(max_width, math.max(min_width, content_width + padding))
 
     -- Open the floating window using our existing function
     local win = M.open_floating_win(buf, { 1, 0 }, {
       focus_on_open = true,
       dismiss_on_move = false,
       -- Override some settings specific to input windows
-      same_file_float_preview = true
+      same_file_float_preview = true,
+      width = width,
+      height = 1 -- Only one line for input
     })
 
     -- Move cursor to the end of any default text
-    local line_length = #(opts.default or "")
-    vim.api.nvim_win_set_cursor(win, { 1, line_length })
+    vim.api.nvim_win_set_cursor(win, { 1, #initial_text })
 
     -- Set window title if we have a prompt
     if vim.fn.has("nvim-0.9.0") == 1 and opts.prompt then
@@ -142,6 +142,7 @@ M.setup_custom_input = function()
     vim.notify("Press <CR> to confirm, <Esc> to cancel", "info")
   end
 end
+
 
 M.remove_win = function(win)
   local curr_buf = vim.api.nvim_get_current_buf()
@@ -235,6 +236,8 @@ local function create_preview_win(buffer, bufpos, zindex, opts)
 
   logger.debug("focus_on_open", enter())
   logger.debug("stack_floating_preview_windows", stack_floating_preview_windows())
+  logger.debug("width" .. vim.inspect(opts.width or M.conf.width), "info")
+  logger.debug("height" .. vim.inspect(opts.height or M.conf.height), "info")
 
   local preview_window
   local curr_win = vim.api.nvim_get_current_win()
@@ -247,16 +250,16 @@ local function create_preview_win(buffer, bufpos, zindex, opts)
   if not stack_floating_preview_windows() and is_floating(curr_win) and success and result == 1 then
     preview_window = curr_win
     vim.api.nvim_win_set_config(preview_window, {
-      width = M.conf.width,
-      height = M.conf.height,
+      width = opts.width or M.conf.width,
+      height = opts.height or M.conf.height,
       border = M.conf.border,
     })
     vim.api.nvim_win_set_buf(preview_window, buffer)
   else
     preview_window = vim.api.nvim_open_win(buffer, enter(), {
       relative = "win",
-      width = M.conf.width,
-      height = M.conf.height,
+      width = opts.width or M.conf.width,
+      height = opts.height or M.conf.height,
       border = M.conf.border,
       bufpos = bufpos,
       zindex = zindex,


### PR DESCRIPTION
I was having a few issues with folke's snacks.nvim `input` plugin where it'd always be off by one character and it was driving me crazy. I'm implementing `vim.ui.input` with goto-preview's floating windows instead. At least temporarily until the issues are fixed.